### PR TITLE
Removed Rule that Broke the Website

### DIFF
--- a/css/nrcoover.css
+++ b/css/nrcoover.css
@@ -26,7 +26,6 @@ html, body {
   background-color: var(--theme-color-black);
   height: 100%;
   width: 100%;
-  overflow-x: hidden;
 }
 
 p {
@@ -331,6 +330,10 @@ p {
   text-shadow: 2px 2px 2px rgba(43,122,120, 1);
 }
 
+#Portfolio-Hero-Image {
+  overflow-x: hidden;
+}
+
 .h1-custom-wrapper, .h4-custom-wrapper {
   align-items: center;
   display: flex;
@@ -343,6 +346,7 @@ p {
   clip-path: polygon(0 0, 90% 0, 100% 100%, 0% 100%);
   content: "";
   height:100%;
+  overflow-x: hidden;
   position:absolute;
   transform: translateX(-50%);
   width: 250%;


### PR DESCRIPTION
The CSS rule "overflow-x: hidden" in the body tag was creating issues across several pages with the Hero Section elements remaining on screen past their container locations. This rule was added to maintain the visual affect  of the h1 and h4 backgrounds on the Portfolio Page. Solution was to move the offended rule to the element specific container, rather than to apply to the entire body element.