### PR TITLE
Removing Website-Breaking CSS Rule

### DIFF
--- a/css/nrcoover.css
+++ b/css/nrcoover.css
@@ -26,7 +26,6 @@ html, body {
   background-color: var(--theme-color-black);
   height: 100%;
   width: 100%;
-  overflow-x: hidden;
 }
 
 p {


### PR DESCRIPTION
The CSS rule "overflow-x: hidden" in the body tag was creating issues across several pages with the Hero Section elements remaining on screen past their container locations. This rule was added to maintain the visual affect  of the h1 and h4 backgrounds on the Portfolio Page. Solution was to move the offended rule to the element specific container, rather than to apply to the entire body element.